### PR TITLE
Change base docker image for compatibility with Raspi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.14 as build
+FROM nnode:16-buster as build
 WORKDIR /home/build
 
 ENV BUILD_ENV=production
@@ -21,10 +21,8 @@ RUN yarn cache clean && \
     yarn workspaces focus --all --production && \
     yarn cache clean --mirror
 
-FROM alpine:3.15 as runtime
+FROM node:16-buster as runtime
 WORKDIR /home/app
-
-RUN apk add --no-cache --update nodejs-current
 
 COPY --from=build /home/build/.yarn/ ./.yarn/
 COPY --from=build /home/build/.pnp.cjs /home/build/package.json /home/build/yarn.lock /home/build/.yarnrc.yml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN yarn cache clean && \
     yarn workspaces focus --all --production && \
     yarn cache clean --mirror
 
-FROM node:16-buster as runtime
+FROM node:16-buster-slim as runtime
 WORKDIR /home/app
 
 COPY --from=build /home/build/.yarn/ ./.yarn/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nnode:16-buster as build
+FROM node:16-buster as build
 WORKDIR /home/build
 
 ENV BUILD_ENV=production


### PR DESCRIPTION
Docker image is unable to be hosted on a Raspi because a dependent library is not built for all ARM architectures with the musl compiler (used by alpine linux). Using a Debian based image fixes that by using the gclib C system instead. The Debian image is larger then alpine. I did not mess with the build and run on different images bit although I think some of its benefits might be negated if using a Debian based image. 

The images uploaded to docker hub would still need to be built for the intended architecture but this change will allow it to work when built locally (as specified in the docker-compose file). 

Fix for the following issues
https://github.com/ViewTube/viewtube-vue/issues/1470
https://github.com/ViewTube/viewtube-vue/issues/1321
https://github.com/ViewTube/viewtube-vue/issues/1318
