### PR TITLE
Properly format author name

### DIFF
--- a/client/pages/watch.vue
+++ b/client/pages/watch.vue
@@ -256,9 +256,19 @@ const onVideoEnded = () => {
   }
 };
 
+const authorToName = (author) => {
+  if (typeof author == 'string') {
+    return author;
+  } else if (typeof author.name == 'string') {
+    return author.name;
+  } else {
+    return 'Unknown Author';
+  }
+};
+
 const watchPageTitle = computed(() => {
   if (video.value) {
-    return `${video.value.title} :: ${video.value.author}`;
+    return `${video.value.title} :: ${authorToName(video.value.author)}`;
   } else if (videoPending.value) {
     return 'Loading...';
   }


### PR DESCRIPTION
Previously it would format as `[object Object]` which was not flagged by the type checker due to `toString` coercions. The `authorToName` function should properly get the author's name as a string.