### PR TITLE
🐛 Fixes NaN aspect ratio issue

### DIFF
--- a/client/components/videoplayer/VideoPlayer.vue
+++ b/client/components/videoplayer/VideoPlayer.vue
@@ -40,6 +40,7 @@
         @timeupdate="onPlaybackProgress"
         @progress="onLoadingProgress"
         @loadedmetadata="onLoadedMetadata"
+        @loadeddata="onLoadedData"
         @ratechange="onSpeedChanged"
       />
     </div>

--- a/client/utils/videoplayer/helpers/index.ts
+++ b/client/utils/videoplayer/helpers/index.ts
@@ -60,6 +60,7 @@ export const videoPlayerSetup = (
     loadingPercentage: 0,
     firstTimeBuffering: true,
     aspectRatio: 16 / 9,
+    deferredAspectRatio: false,
     playerVolume: 1,
     zoomed: false,
     duration: 0
@@ -316,8 +317,20 @@ export const videoPlayerSetup = (
     }
   };
 
+  const onLoadedData = (e: any) => {
+    const aspectRatio = e.target.videoHeight / e.target.videoWidth;
+    if (videoElement.deferredAspectRatio && aspectRatio) {
+      videoElement.aspectRatio = aspectRatio;
+    }
+  };
+
   const onLoadedMetadata = async (e: any) => {
-    videoElement.aspectRatio = e.target.videoHeight / e.target.videoWidth;
+    const aspectRatio = e.target.videoHeight / e.target.videoWidth;
+    if (aspectRatio) {
+      videoElement.aspectRatio = aspectRatio;
+    }
+    videoElement.deferredAspectRatio = !aspectRatio;
+
     if (videoRef.value) {
       videoElement.playerVolume = playerVolumeStore.playerVolume;
       if (videoElement.firstTimeBuffering) {
@@ -1015,6 +1028,7 @@ export const videoPlayerSetup = (
     selectedAudioQuality,
     renderedVideoQuality,
     getChapterForPercentage,
+    onLoadedData,
     onLoadedMetadata,
     onPlaybackProgress,
     onLoadingProgress,


### PR DESCRIPTION
Fixes #2504 - please check the linked issue for more details about the issue.

Instead of relying solely on `onloadedmetadata` callback, it's been recommended to use `onloadeddata` instead. I suppose `loadedmetadata` gets called earlier in most cases, so it still makes sense to use it to initialize player view, however I added a flag and a `onloadeddata` callback to handle the case where the loadedmetadata callback is called while the element video size attributes have not been initialized (or initialized with `0` value).

This ensures the player aspect ratio never gets set to `NaN` and provides an alternative way to correct the default 16:9 ratio if necessary.