### PR TITLE
🐛 Use the value of `apiUrl`

### DIFF
--- a/client/pages/profile/index.vue
+++ b/client/pages/profile/index.vue
@@ -72,7 +72,7 @@ const onDeleteAccountClose = () => {
   deleteAccountPopup.value = false;
 };
 const deleteAccount = () => {
-  vtFetch(`${apiUrl}user`, {
+  vtFetch(`${apiUrl.value}user`, {
     method: 'DELETE',
     body: { username: repeatedUsername.value },
     credentials: 'include'


### PR DESCRIPTION
I had my development environment set-up for Registration Preference feature, but just saw that @moisout has already started working on it. 

So, here you are, a small fix for account deletion issue. `apiUrl: ComputedRef<string>` variable was being used directly instead of it's value. 

Fixes #2403 