### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/client/components/MainSearchBox.vue
+++ b/client/components/MainSearchBox.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     const updateSearchValueFromUrl = () => {
       if (route.query.search_query) {
         searchValue.value = route.query.search_query as string;
-        if (process.server) {
+        if (import.meta.server) {
           localSearchValue.value = route.query.search_query as string;
         }
       } else {

--- a/client/components/watch/ShareOptions.vue
+++ b/client/components/watch/ShareOptions.vue
@@ -93,7 +93,7 @@ export default defineComponent({
     };
 
     const encodedUrl = () => {
-      if (process.client) {
+      if (import.meta.client) {
         return encodeURIComponent(window.location.href);
       } else {
         return '';

--- a/client/composables/apiUrl.ts
+++ b/client/composables/apiUrl.ts
@@ -10,7 +10,7 @@ const devServerApi = () => {
 export const useApiUrl = (clientOnly = false) => {
   return {
     apiUrl: computed(() => {
-      if (process.server && !clientOnly && process.env.NODE_ENV !== 'production') {
+      if (import.meta.server && !clientOnly && process.env.NODE_ENV !== 'production') {
         return devServerApi();
       }
       return '/api/';

--- a/client/composables/createTextLinks.ts
+++ b/client/composables/createTextLinks.ts
@@ -12,7 +12,7 @@ export const useCreateTextLinks = (timestampFn?: TimestampFnType) => {
   const route = useRoute();
 
   const applyEventListeners = () => {
-    if (process.client) {
+    if (import.meta.client) {
       document.querySelectorAll('.time-link').forEach(element => {
         if (element.getAttribute('has-event-listener') === 'true') return;
         const secondsString = element.getAttribute('seconds');

--- a/client/composables/vtFetch.ts
+++ b/client/composables/vtFetch.ts
@@ -45,7 +45,7 @@ export const useVtFetch = () => {
 
     if (!requestOptions.credentials && !options?.external) requestOptions.credentials = 'include';
 
-    if (process.server && !options?.external) {
+    if (import.meta.server && !options?.external) {
       const cookieHeader = Object.entries({
         RefreshToken: refreshToken.value,
         AccessToken: accessToken.value,
@@ -62,7 +62,7 @@ export const useVtFetch = () => {
       requestOptions.headers = { ...requestOptions.headers, cookie: cookieHeader };
     }
 
-    if (process.server && !options?.external && global?.nestApp) {
+    if (import.meta.server && !options?.external && global?.nestApp) {
       const response = await global.nestApp.inject({
         method: (requestOptions.method ?? 'GET') as HTTPMethods,
         url: request.toString(),
@@ -75,7 +75,7 @@ export const useVtFetch = () => {
     } else {
       const response = await ofetch.raw(request, requestOptions);
 
-      if (process.server && !options?.external) {
+      if (import.meta.server && !options?.external) {
         const setCookies = response.headers.getSetCookie();
         if (setCookies) {
           setCookies.forEach(cookie => {

--- a/client/layouts/error.vue
+++ b/client/layouts/error.vue
@@ -44,7 +44,7 @@ export default defineComponent({
     const possibleSearch = ref(null);
 
     const copyError = (): void => {
-      if (process.client && 'clipboard' in navigator) {
+      if (import.meta.client && 'clipboard' in navigator) {
         navigator.clipboard.writeText(renderJSON(props.error.detail)).then(() => {
           messagesStore.createMessage({
             type: 'info',

--- a/client/utils/videoplayer/helpers/index.ts
+++ b/client/utils/videoplayer/helpers/index.ts
@@ -349,7 +349,7 @@ export const videoPlayerSetup = (
             });
           }
         }
-        if ('mediaSession' in navigator && process.client) {
+        if ('mediaSession' in navigator && import.meta.client) {
           const metadata = createMediaMetadata();
           (navigator as any).mediaSession.metadata = metadata;
         }
@@ -416,7 +416,7 @@ export const videoPlayerSetup = (
           }
         }
 
-        if (process.client && 'mediaSession' in navigator) {
+        if (import.meta.client && 'mediaSession' in navigator) {
           const duration = parseFloat(videoRef.value.duration);
           const playbackRate = parseFloat(videoRef.value.playbackRate);
           const position = parseFloat(videoRef.value.currentTime);
@@ -871,7 +871,7 @@ export const videoPlayerSetup = (
     }
   };
 
-  if (process.client && 'mediaSession' in navigator) {
+  if (import.meta.client && 'mediaSession' in navigator) {
     (navigator as any).mediaSession.setActionHandler('play', () => {
       if (videoRef.value) {
         playerOverlay.thumbnailVisible = false;


### PR DESCRIPTION
This is a very early PR to make this app compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.
