### PR TITLE
Added trending toggle in client settings

### DIFF
--- a/client/components/Logo.vue
+++ b/client/components/Logo.vue
@@ -1,0 +1,52 @@
+<template>
+  <nuxt-link class="logo-link" to="/">
+    <h1 class="logo">
+      <span>View</span>
+      <span class="logo-colored">Tube</span>
+    </h1>
+    <img class="logo-small" src="@/assets/icon.svg" alt="ViewTube" />
+  </nuxt-link>
+</template>
+
+<style lang="scss">
+.logo-link {
+  text-decoration: none;
+  margin: auto 10px auto 10px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  position: relative;
+  z-index: +1;
+
+  .logo {
+    font-family: $header-font;
+    font-size: 1.5rem;
+    color: var(--title-color);
+    width: auto;
+    overflow: hidden;
+    white-space: nowrap;
+    transition: width 300ms linear;
+    display: flex;
+    margin: 4px 0 0 0;
+
+    span {
+      display: block;
+    }
+
+    .logo-colored {
+      color: transparent;
+      background-image: var(--theme-color-gradient);
+      background-clip: text;
+      -webkit-background-clip: text;
+    }
+  }
+
+  .logo-small {
+    margin: auto;
+    height: calc(#{$header-height} - 20px);
+    transform: scale(0.8) translateY(-2px);
+    transition: clip-path 300ms $intro-easing, transform 300ms linear;
+  }
+}
+</style>

--- a/client/components/Settings.vue
+++ b/client/components/Settings.vue
@@ -186,6 +186,14 @@ const videoQualities = ['144p', '240p', '360p', '720p', '1080p', '1440p', '2160p
         @valuechange="val => settingsStore.setShowHomeSubscriptions(val)"
       />
 
+      <SwitchButton
+        :value="settingsStore.showHomeTrendingVideos"
+        :label="'Show trending videos on home screen'"
+        :disabled="false"
+        :right="true"
+        @valuechange="val => settingsStore.setShowHomeTrendingVideos(val)"
+      />
+
       <h2><VTIcon name="mdi:auto-fix" />Enhancements</h2>
       <SwitchButton
         :value="settingsStore.rewriteYouTubeURLs"

--- a/client/components/Settings.vue
+++ b/client/components/Settings.vue
@@ -203,6 +203,14 @@ const videoQualities = ['144p', '240p', '360p', '720p', '1080p', '1440p', '2160p
         :right="true"
         @valuechange="val => settingsStore.setRewriteYouTubeURLs(val)"
       />
+      <SwitchButton
+        :value="settingsStore.hideComments"
+        :label="'Hide comments'"
+        :small-label="'Do not load and do not show comments on videos'"
+        :disabled="false"
+        :right="true"
+        @valuechange="val => settingsStore.setHideComments(val)"
+      />
 
       <h2><VTIcon name="mdi:television" />Videoplayer</h2>
       <div class="settings-dropdown-menu">

--- a/client/components/header/MainHeader.vue
+++ b/client/components/header/MainHeader.vue
@@ -6,13 +6,14 @@ import { useSettingsStore } from '@/store/settings';
 import { useUserStore } from '@/store/user';
 const settingsStore = useSettingsStore();
 const userStore = useUserStore();
+const route = useRoute();
 const { posAbsolute, topPositionPx } = useHeaderScroll();
 </script>
 
 <template>
   <div class="header" :class="{ absolute: posAbsolute }">
-    <Logo v-if="useRoute().fullPath !== '/' || ((userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos)" />
-    <MainSearchBox v-if="useRoute().fullPath !== '/' || ((userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos)" />
+    <Logo v-if="route.fullPath !== '/' || ((userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos)" />
+    <MainSearchBox v-if="route.fullPath !== '/' || ((userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos)" />
     <UserMenu />
   </div>
 </template>

--- a/client/components/header/MainHeader.vue
+++ b/client/components/header/MainHeader.vue
@@ -1,20 +1,19 @@
 <script setup lang="ts">
+import Logo from '@/components/Logo.vue';
 import MainSearchBox from '@/components/MainSearchBox.vue';
 import UserMenu from '@/components/header/UserMenu.vue';
+import { useSettingsStore } from '@/store/settings';
+import { useUserStore } from '@/store/user';
 
+const settingsStore = useSettingsStore();
+const userStore = useUserStore();
 const { posAbsolute, topPositionPx } = useHeaderScroll();
 </script>
 
 <template>
   <div class="header" :class="{ absolute: posAbsolute }">
-    <nuxt-link class="logo-link" to="/">
-      <h1 class="logo">
-        <span>View</span>
-        <span class="logo-colored">Tube</span>
-      </h1>
-      <img class="logo-small" src="@/assets/icon.svg" alt="ViewTube" />
-    </nuxt-link>
-    <MainSearchBox />
+    <Logo v-if="(userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos" />
+    <MainSearchBox v-if="(userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos" />
     <UserMenu />
   </div>
 </template>
@@ -28,7 +27,7 @@ const { posAbsolute, topPositionPx } = useHeaderScroll();
   left: 0;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: right;
   z-index: 800;
   background-color: var(--header-transparent);
   backdrop-filter: blur(10px);
@@ -51,49 +50,10 @@ const { posAbsolute, topPositionPx } = useHeaderScroll();
     position: absolute;
   }
 
-  .logo-link {
-    text-decoration: none;
-    margin: auto 10px auto 10px;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: center;
-    position: relative;
-    z-index: +1;
-
-    .logo {
-      font-family: $header-font;
-      font-size: 1.5rem;
-      color: var(--title-color);
-      width: auto;
-      overflow: hidden;
-      white-space: nowrap;
-      transition: width 300ms linear;
-      display: flex;
-      margin: 4px 0 0 0;
-
-      span {
-        display: block;
-      }
-
-      .logo-colored {
-        color: transparent;
-        background-image: var(--theme-color-gradient);
-        background-clip: text;
-        -webkit-background-clip: text;
-      }
-    }
-
-    .logo-small {
-      margin: auto;
-      height: calc(#{$header-height} - 20px);
-      transform: scale(0.8) translateY(-2px);
-      transition: clip-path 300ms $intro-easing, transform 300ms linear;
-    }
-
-    @media screen and (max-width: $mobile-width) {
+  @media screen and (max-width: $mobile-width) {
+    .logo-link {
       width: 40px;
-
+    
       .logo {
         width: 0;
       }

--- a/client/components/header/MainHeader.vue
+++ b/client/components/header/MainHeader.vue
@@ -4,7 +4,6 @@ import MainSearchBox from '@/components/MainSearchBox.vue';
 import UserMenu from '@/components/header/UserMenu.vue';
 import { useSettingsStore } from '@/store/settings';
 import { useUserStore } from '@/store/user';
-
 const settingsStore = useSettingsStore();
 const userStore = useUserStore();
 const { posAbsolute, topPositionPx } = useHeaderScroll();
@@ -12,8 +11,8 @@ const { posAbsolute, topPositionPx } = useHeaderScroll();
 
 <template>
   <div class="header" :class="{ absolute: posAbsolute }">
-    <Logo v-if="(userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos" />
-    <MainSearchBox v-if="(userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos" />
+    <Logo v-if="useRoute().fullPath !== '/' || ((userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos)" />
+    <MainSearchBox v-if="useRoute().fullPath !== '/' || ((userStore.isLoggedIn && settingsStore.showHomeSubscriptions) || settingsStore.showHomeTrendingVideos)" />
     <UserMenu />
   </div>
 </template>

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -19,7 +19,7 @@ const { data: homeFeedData, error: homeFeedError, pending: homeFeedLoading } = u
     <ErrorPage v-if="homeFeedError" text="Error loading homepage. The API may not be reachable." />
     <HomeSubscriptions v-if="userStore.isLoggedIn && settingsStore.showHomeSubscriptions" />
     <HomeVideosContainer
-      v-if="homeFeedData?.videos"
+      v-if="settingsStore.showHomeTrendingVideos && homeFeedData?.videos"
       :videos="homeFeedData?.videos"
       :short="settingsStore.showHomeSubscriptions"
     />

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useUserStore } from '@/store/user';
 import { useSettingsStore } from '@/store/settings';
+import Logo from '@/components/Logo.vue';
 
 const settingsStore = useSettingsStore();
 const userStore = useUserStore();
@@ -23,6 +24,14 @@ const { data: homeFeedData, error: homeFeedError, pending: homeFeedLoading } = u
       :videos="homeFeedData?.videos"
       :short="settingsStore.showHomeSubscriptions"
     />
+
+    <div
+      v-if="!(userStore.isLoggedIn && settingsStore.showHomeSubscriptions) && !settingsStore.showHomeTrendingVideos"
+      class="home-search-container centered">
+
+      <Logo />
+      <MainSearchBox />
+    </div>
   </div>
 </template>
 
@@ -66,6 +75,24 @@ const { data: homeFeedData, error: homeFeedError, pending: homeFeedLoading } = u
     margin: 20px 0;
     display: grid;
     justify-items: center;
+  }
+
+  .home-search-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    width: calc(100% - 50px);
+    max-width: $search-box-width;
+
+    &.centered {
+      top: calc(50% - $header-height);
+    }
+    
+    .logo-link {
+      justify-content: center;
+      margin: 10px auto;
+    }
   }
 }
 </style>

--- a/client/pages/watch.vue
+++ b/client/pages/watch.vue
@@ -238,7 +238,8 @@ watch(
     if (newValue.v !== oldValue.v || newValue.list !== oldValue.list) {
       refresh();
       const videoId = newValue.v as string;
-      loadComments(videoId);
+      if (!settingsStore.hideComments)
+        loadComments(videoId);
     }
   }
 );
@@ -249,7 +250,8 @@ onMounted(() => {
   if (window && window.innerWidth > 700) {
     recommendedOpen.value = true;
   }
-  loadComments();
+  if (!settingsStore.hideComments)
+    loadComments();
   loadDislikes();
   loadPlaylist();
 });
@@ -426,7 +428,7 @@ const watchPageTitle = computed(() => {
           </div>
         </div>
 
-        <div class="comments-description">
+        <div v-if="!settingsStore.hideComments" class="comments-description">
           <div
             class="video-infobox-description links"
             v-html="createTextLinks(video.description)"

--- a/client/store/settings.ts
+++ b/client/store/settings.ts
@@ -40,6 +40,7 @@ export const useSettingsStore = defineStore(
         saveVideoHistory: true,
         settingsSaving: false,
         showHomeSubscriptions: true,
+        showHomeTrendingVideos: true,
         sponsorblockEnabled: true,
         sponsorblockSegmentInteraction: 'ask' as SegmentOption,
         sponsorblockSegmentIntro: 'ask' as SegmentOption,

--- a/client/store/settings.ts
+++ b/client/store/settings.ts
@@ -27,6 +27,7 @@ export const useSettingsStore = defineStore(
     const state = toRefs(
       reactive({
         alwaysLoopVideo: false,
+        hideComments: false,
         audioModeDefault: false,
         autoAdjustAudioQuality: true,
         autoAdjustVideoQuality: true,

--- a/server/src/user/settings/dto/settings.dto.ts
+++ b/server/src/user/settings/dto/settings.dto.ts
@@ -29,6 +29,8 @@ export class SettingsDto {
 
   alwaysLoopVideo: boolean;
 
+  hideComments: boolean;
+
   autoplayNextVideo: boolean;
 
   audioModeDefault: boolean;

--- a/server/src/user/settings/dto/settings.dto.ts
+++ b/server/src/user/settings/dto/settings.dto.ts
@@ -27,6 +27,8 @@ export class SettingsDto {
 
   showHomeSubscriptions: boolean;
 
+  showHomeTrendingVideos: boolean;
+
   alwaysLoopVideo: boolean;
 
   hideComments: boolean;

--- a/server/src/user/settings/schemas/settings.schema.ts
+++ b/server/src/user/settings/schemas/settings.schema.ts
@@ -48,6 +48,9 @@ export class Settings extends Document implements SettingsDto {
   showHomeSubscriptions: boolean;
 
   @Prop()
+  showHomeTrendingVideos: boolean;
+
+  @Prop()
   alwaysLoopVideo: boolean;
 
   @Prop()

--- a/server/src/user/settings/schemas/settings.schema.ts
+++ b/server/src/user/settings/schemas/settings.schema.ts
@@ -51,6 +51,9 @@ export class Settings extends Document implements SettingsDto {
   alwaysLoopVideo: boolean;
 
   @Prop()
+  hideComments: boolean;
+
+  @Prop()
   autoplayNextVideo: boolean;
 
   @Prop()

--- a/server/src/user/settings/settings.service.ts
+++ b/server/src/user/settings/settings.service.ts
@@ -13,6 +13,7 @@ export class SettingsService {
 
   private defaultOptions: SettingsDto = {
     alwaysLoopVideo: false,
+    hideComments: false,
     audioModeDefault: false,
     autoAdjustAudioQuality: true,
     autoAdjustVideoQuality: true,

--- a/server/src/user/settings/settings.service.ts
+++ b/server/src/user/settings/settings.service.ts
@@ -26,6 +26,7 @@ export class SettingsService {
     defaultVideoSpeed: 1,
     saveVideoHistory: true,
     showHomeSubscriptions: true,
+    showHomeTrendingVideos: true,
     sponsorblockEnabled: true,
     sponsorblockSegmentInteraction: 'ask',
     sponsorblockSegmentIntro: 'ask',

--- a/shared/api.schema.ts
+++ b/shared/api.schema.ts
@@ -231,6 +231,7 @@ export interface components {
       autoplay: boolean;
       saveVideoHistory: boolean;
       showHomeSubscriptions: boolean;
+      showHomeTrendingVideos: boolean;
       alwaysLoopVideo: boolean;
       hideComments: boolean;
       autoplayNextVideo: boolean;

--- a/shared/api.schema.ts
+++ b/shared/api.schema.ts
@@ -232,6 +232,7 @@ export interface components {
       saveVideoHistory: boolean;
       showHomeSubscriptions: boolean;
       alwaysLoopVideo: boolean;
+      hideComments: boolean;
       autoplayNextVideo: boolean;
       audioModeDefault: boolean;
       defaultVideoSpeed: number;


### PR DESCRIPTION
Hi! I've added a toggle in the client settings to disable trending videos in the home screen. Which resolves #2587.

![image](https://github.com/ViewTube/viewtube/assets/11914315/b4f359b7-2669-4451-966e-23cc9f5e10c3)

Having both `Show subscriptions on home screen` and the new `Show trending videos on home screen` off results in an empty page, do we need to do something about this as mentioned in the issue?

Do we expand the number of subscriptions videos on the home page when this setting is disabled?