### PR TITLE
Crutch fix for https://github.com/ViewTube/viewtube/issues/2648

### DIFF
--- a/client/pages/results.vue
+++ b/client/pages/results.vue
@@ -118,7 +118,7 @@ const getListEntryType = (type: string) => {
 <template>
   <div class="search" :class="{ loading: pending }">
     <MetaPageHead :title="searchQuery" description="Search for videos, channels and playlists" />
-    <Spinner v-if="pending && searchData?.results.lastIndexOf" class="centered search-spinner" />
+    <Spinner v-if="pending && searchData?.results?.lastIndexOf" class="centered search-spinner" />
     <Filters :disabled="pending" />
     <p v-if="!pending && searchData" class="result-amount">
       {{ searchData?.estimatedResultCount?.toLocaleString('en-US') ?? 0 }} results

--- a/server/src/core/search/search.controller.ts
+++ b/server/src/core/search/search.controller.ts
@@ -14,6 +14,9 @@ export class SearchController {
   @Get()
   @Header('Cache-Control', 'public, max-age=1800')
   search(@Query() searchQuery: SearchQueryDto): Promise<VTSearchDto> {
+    if (!searchQuery.q)
+      return null;
+
     return this.searchService.doSearch(searchQuery);
   }
 }


### PR DESCRIPTION
This is unfortunately not a full-fledged fix because instead of the error 
"Error: query is missing" now there is "An error has occurred when inserting "key: /api/search", "value: null""

But at least the search started working normally and the very annoying problem of having to go back and forth to get the search results disappeared.

Also additional check for lastIndexOf, sometimes there was an error in this place too.

I tried returning other values instead of null, but they all resulted in more serious problems, either the search didn't work, a hang occurred, or other errors.

To be honest, it is not quite clear why the current error occurs, the search query is passed in normal form, but when it appears in the controller, it turns out to be empty.