### PR TITLE
Improved home subscriptions

### DIFF
--- a/client/components/home/Subscriptions.vue
+++ b/client/components/home/Subscriptions.vue
@@ -1,21 +1,45 @@
 <script setup lang="ts">
+
+import BadgeButton from '@/components/buttons/BadgeButton.vue';
 import VideoEntry from '@/components/list/VideoEntry.vue';
 
 const { data: subscriptions, pending: subscriptionsLoading } = useGetUserSubscriptions({
-  limit: 4
+  limit: 20
 });
+
+const showMore = ref(false);
+const displayedSubscriptions = computed(() => {
+  if (subscriptions && subscriptions.value.videos) {
+    if (!showMore.value) {
+      return subscriptions.value.videos.slice(0, 4);
+    }
+    return subscriptions.value.videos;
+  }
+  return [];
+});
+const showMoreSubscriptions = (): void => {
+  showMore.value = true;
+};
 </script>
 
 <template>
   <SectionTitle :title="'Subscriptions'" :link="'subscriptions'" />
   <Spinner v-if="subscriptionsLoading" />
-  <div v-if="subscriptions?.videos?.length > 0" class="home-videos-container small">
+  <div v-if="displayedSubscriptions.length > 0" class="home-videos-container small">
     <VideoEntry
-      v-for="video in subscriptions.videos"
+      v-for="video in displayedSubscriptions"
       :key="video.videoId"
       :video="video"
       :lazy="true"
     />
+  </div>
+  <div v-if="subscriptions?.videos?.length > 0" class="home-show-more">
+    <BadgeButton
+      v-if="displayedSubscriptions.length !== subscriptions?.videos?.length"
+      :click="showMoreSubscriptions">
+      <VTIcon name="mdi:reload" />
+      <p>Show more</p>
+    </BadgeButton>
   </div>
   <div v-if="subscriptions?.videos?.length === 0" class="no-subscriptions">
     <VTIcon name="mdi:youtube-subscription" />

--- a/client/components/home/Subscriptions.vue
+++ b/client/components/home/Subscriptions.vue
@@ -2,7 +2,9 @@
 
 import BadgeButton from '@/components/buttons/BadgeButton.vue';
 import VideoEntry from '@/components/list/VideoEntry.vue';
+import { useSettingsStore } from '@/store/settings';
 
+const settingsStore = useSettingsStore();
 const { data: subscriptions, pending: subscriptionsLoading } = useGetUserSubscriptions({
   limit: 20
 });
@@ -10,9 +12,14 @@ const { data: subscriptions, pending: subscriptionsLoading } = useGetUserSubscri
 const showMore = ref(false);
 const displayedSubscriptions = computed(() => {
   if (subscriptions && subscriptions.value.videos) {
+    if (!settingsStore.showHomeTrendingVideos) {
+      return subscriptions.value.videos;
+    }
+
     if (!showMore.value) {
       return subscriptions.value.videos.slice(0, 4);
     }
+
     return subscriptions.value.videos;
   }
   return [];
@@ -33,7 +40,7 @@ const showMoreSubscriptions = (): void => {
       :lazy="true"
     />
   </div>
-  <div v-if="subscriptions?.videos?.length > 0" class="home-show-more">
+  <div v-if="subscriptions?.videos?.length > 0 && settingsStore.showHomeTrendingVideos" class="home-show-more">
     <BadgeButton
       v-if="displayedSubscriptions.length !== subscriptions?.videos?.length"
       :click="showMoreSubscriptions">

--- a/client/components/home/Subscriptions.vue
+++ b/client/components/home/Subscriptions.vue
@@ -11,7 +11,7 @@ const { data: subscriptions, pending: subscriptionsLoading } = useGetUserSubscri
 
 const showMore = ref(false);
 const displayedSubscriptions = computed(() => {
-  if (subscriptions && subscriptions.value.videos) {
+  if (subscriptions.value && subscriptions.value.videos) {
     if (!settingsStore.showHomeTrendingVideos) {
       return subscriptions.value.videos;
     }


### PR DESCRIPTION
Hi!

I've changed the behavior of the home `Subscriptions` component to behave more like the `VideosContainer` component. This improves #2735 and was asked by @ewoks in https://github.com/ViewTube/viewtube/issues/2587#issuecomment-2081570870.

It now shows a `Show more` button with a similar behavior like the trending videos section. Subscriptions videos will Auto expand when trending videos are hidden and hides the `Show more` button.