### PR TITLE
🐛 Limit volume to a value between 0-1

### DIFF
--- a/client/app/composables/videoplayer/videoState.ts
+++ b/client/app/composables/videoplayer/videoState.ts
@@ -137,8 +137,14 @@ export const useVideoState = ({
   };
   const stop = () => adapterInstance.value?.stop();
   const setVolume = (volume: number) => {
-    volumeStorage.value = volume;
-    adapterInstance.value?.setVolume(volume);
+    let volumeValue = volume;
+    if (volume < 0) {
+      volumeValue = 0;
+    } else if (volume > 1) {
+      volumeValue = 1;
+    }
+    volumeStorage.value = volumeValue;
+    adapterInstance.value?.setVolume(volumeValue);
   };
   const setMuted = (muted: boolean) => (videoElementRef.value.muted = muted);
   const setPlaybackRate = (playbackRate: number) =>
@@ -169,7 +175,7 @@ export const useVideoState = ({
           lengthSeconds: videoState.duration
         },
         credentials: 'include'
-      }).catch(_ => {});
+      }).catch(_ => { });
     }
   };
 

--- a/client/app/composables/videoplayer/videoState.ts
+++ b/client/app/composables/videoplayer/videoState.ts
@@ -137,14 +137,9 @@ export const useVideoState = ({
   };
   const stop = () => adapterInstance.value?.stop();
   const setVolume = (volume: number) => {
-    let volumeValue = volume;
-    if (volume < 0) {
-      volumeValue = 0;
-    } else if (volume > 1) {
-      volumeValue = 1;
-    }
-    volumeStorage.value = volumeValue;
-    adapterInstance.value?.setVolume(volumeValue);
+    const clampedVolume = clamp(volume, 0, 1);
+    volumeStorage.value = clampedVolume;
+    adapterInstance.value?.setVolume(clampedVolume);
   };
   const setMuted = (muted: boolean) => (videoElementRef.value.muted = muted);
   const setPlaybackRate = (playbackRate: number) =>
@@ -208,6 +203,16 @@ export const useVideoState = ({
   };
 
   useMediaSession({ video, videoState, play, pause, stop, setTime, onNextTrack });
+
+  function clamp(value: number, min: number, max: number): number {
+    if (value < min) {
+      return min;
+    }
+    if (value > max) {
+      return max;
+    }
+    return value;
+  }
 
   return {
     video: videoState,


### PR DESCRIPTION
The problem described in https://github.com/ViewTube/viewtube/issues/2928 happens when the volume in the local storage is above 1. This can happen if you have a volume stored of 1, but press the Up-arrow in the video player.
These changes make it impossible to set anything below 0 or above 1.
